### PR TITLE
로그인 전에 루트 URL로 접속시 로그인 페이지로 이동하지 않는 오류 해결

### DIFF
--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -286,7 +286,7 @@ router.post("/verify-token", async (req, res) => {
 
   if (!accessToken) {
     return res
-      .status(401)
+      .status(200)
       .json({ isValid: false, message: "토큰이 유효하지 않습니다." });
   }
 
@@ -296,14 +296,14 @@ router.post("/verify-token", async (req, res) => {
     const user = await User.findById(decoded.userId);
     if (!user || !user.refreshToken) {
       return res
-        .status(401)
+        .status(200)
         .json({ isValid: false, message: "로그인이 만료되었습니다." });
     }
 
     return res.status(200).json({ isValid: true, user: decoded });
   } catch (error) {
     return res
-      .status(401)
+      .status(200)
       .json({ isValid: false, message: "토큰이 유효하지 않습니다." });
   }
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,8 +8,8 @@ export function App() {
 
   const verifyToken = async () => {
     try {
-      await axiosInstance.post("/auth/verify-token");
-      setIsAuthenticated(true);
+      const res = await axiosInstance.post("/auth/verify-token");
+      setIsAuthenticated(res.data.isValid);
     } catch (error) {
       console.log("토큰 인증 실패: ", error);
       setIsAuthenticated(false);


### PR DESCRIPTION
## 문제 상황
`/verify-token`에서 토큰이 유효하지 않으면 401 에러와 함께 `{ isValid: false, message: "토큰이 유효하지 않습니다." }` 와 같은 형식의 에러 메시지를 반환한다.
이때 클라이언트와 응답 구조가 달라서, 로그인 전에 루트 URL로 접속시 로그인 페이지로 이동하지 않는 오류가 발생했다.

## 과정
클라이언트에서 로그인 여부 판단을 응답 코드(ex. 200, 401)가 아닌 `response.data.isValid`로 판단하도록 변경했다.

## 결과
로그인 이전에 로그인이 필요한 URL로 접속 시, `/login`으로 이동한다.