### PR TITLE
지원 현황 생성/수정 페이지의 버그 픽스

### DIFF
--- a/frontend/src/pages/createpage/index.tsx
+++ b/frontend/src/pages/createpage/index.tsx
@@ -270,7 +270,7 @@ const CreatePage = () => {
                     id='date'
                     variant='outline'
                   >
-                    {date ? date.toLocaleDateString() : 'Select date'}
+                    {date && date.toLocaleDateString()}
                     <ChevronDownIcon />
                   </ShadcnButton>
                 </PopoverTrigger>
@@ -279,8 +279,10 @@ const CreatePage = () => {
                     captionLayout='dropdown'
                     mode='single'
                     selected={date}
-                    onSelect={(date) => {
-                      setDate(date);
+                    onSelect={(newDate) => {
+                      if (newDate) {
+                        setDate(newDate);
+                      }
                       setOpen(false);
                     }}
                   />

--- a/frontend/src/pages/createpage/index.tsx
+++ b/frontend/src/pages/createpage/index.tsx
@@ -103,8 +103,11 @@ const CreatePage = () => {
       setStages(jobData.stages);
       setProgressStatus(jobData.progress);
       setFileList(jobData.fileUrl);
-      const parsedBlocks = JSON.parse(jobData.contents);
-      editor.replaceBlocks(editor.document, parsedBlocks);
+
+      if (jobData.contents) {
+        const parsedBlocks = JSON.parse(jobData.contents);
+        editor.replaceBlocks(editor.document, parsedBlocks);
+      }
     }
   }, [jobData, editor]);
 

--- a/frontend/src/pages/createpage/index.tsx
+++ b/frontend/src/pages/createpage/index.tsx
@@ -290,7 +290,7 @@ const CreatePage = () => {
 
             <Field>
               <FieldLabel htmlFor='progress'>진행 여부</FieldLabel>
-              <Select value={progressStatus} onValueChange={setProgressStatus}>
+              <Select key={id ? progressStatus : 'create'} value={progressStatus} onValueChange={setProgressStatus}>
                 <SelectTrigger className='border-white-200 cursor-pointer rounded-lg border px-2 py-1 font-normal shadow-none'>
                   <SelectValue />
                 </SelectTrigger>


### PR DESCRIPTION
## 🚀 이슈 번호

- #19

## 💬 작업 내용

1. **수정 페이지 진입시 JSON 파싱 에러 해결**
  - 문제: jobData.contents(메모)가 비어있는 상태에서 수정 페이지로 진입하면, BlockNote로 초기화하는 과정에서 JSON 파싱 에러 발생
  - 해결: jobData.contents가 존재하는지 먼저 확인하는 조건문 추가 & 빈 문자열일 경우 파싱 방지
2. **이미 선택한 날짜를 재선택하면 'Select date' 문구가 뜨는 에러 해결**
  - 문제: 사용자가 캘린더에서 이미 선택한 날짜를 다시 클릭하면 undefined가 전달되면서 날짜가 사라지고 'Select date' 문구가 표시됨
  - 해결: 기본적으로 당일로 초기화 되기 때문에, 날짜가 없을 때 fallback 텍스트를 제거 & 캘린더 onSelect에서 newDate가 존재할 때만 상태 업데이트 → 같은 날짜 재선택 시 undefined가 와도 기존 날짜 유지
3. **수정 페이지 진입 시 기존에 저장된 진행 여부(progressStatus)가 UI에 표시되지 않음**
  - 문제: value prop으로 상태값을 전달했지만 Select 컴포넌트가 제대로 리렌더링되지 않음
  - 해결: Select 컴포넌트에 key prop을 추가해 진행 여부가 변경될 때마다 컴포넌트 업데이트를 강제하여 기존 값 표시
